### PR TITLE
Support linking JIRA issue in the existing test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 #IntellJ
 /idea/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,29 +1,56 @@
-## katalon-studio-jira-plugin
+**Table of Content**
 
-The main purpose is supporting Katalon - JIRA integration:
+<!--TOC-->
+
+- [About](#about)
+- [Contribution](#contribution)
+  - [Resources](#resources)
+  - [Setup development environment](#setup-development-environment)
+  - [Development tasks](#development-tasks)
+    - [Create build package](#create-build-package)
+- [Katalon products](#katalon-products)
+  - [Katalon TestOps](#katalon-testops)
+  - [Katalon Studio](#katalon-studio)
+- [Update **Table of Content** section in the README file](#update-table-of-content-section-in-the-readme-file)
+
+<!--TOC-->
+
+---
+
+# About
+
+A Katalon Studio plugin to support the integration with JIRA (self-hosted and cloud-based). This plugin provides the following features:
 
 - Submitting Katalon test run result as a JIRA issue.
 - Creating a Katalon test case from a BDD description from JIRA
 
-#### Build
-Requirements:
+# Contribution
 
-- JDK 1.8
+## Resources
+
+- [Katalon Studio plugin development guide](https://github.com/katalon-studio/katalon-studio-platform/blob/master/docs/tutorials/create-your-first-plugin.md)
+- [Install plugin offline in Studio](https://docs.katalon.com/katalon-platform/plugins-and-add-ons/katalon-store/katalon-studio-plugins/installing-plugin-offline-in-katalon-studio#install-plugins-offline)
+
+## Setup development environment
+
+Install the following tools:
+
+- JDK 17
 - Maven 3.3+
 
-Build
+## Development tasks
 
-`mvn clean package`
+### Create build package
 
-#### How to test in Katalon Studio
+```shell script
+mvn clean package
+```
 
-- Checkout or get a build of branch `staging-plugin` of KS
-- After KS opens, please click on `Plugin` menu, select `Install Plugin` and choose the generated jar file.
-- If you want to reload this plugin, please click on `Plugin` menu, select `Uninstall Plugin` then select `Install Plugin` again. 
+The command produces a jar file at `target/katalon-studio-jira-plugin-...jar`
 
-## Companion products
+# Katalon products
 
-### Katalon TestOps
+## Katalon TestOps
 
 [Katalon TestOps](https://analytics.katalon.com) is a web-based application that provides dynamic perspectives and an insightful look at your automation testing data. You can leverage your automation testing data by transforming and visualizing your data; analyzing test results; seamlessly integrating with such tools as Katalon Studio and Jira; maximizing the testing capacity with remote execution.
 
@@ -33,5 +60,17 @@ Build
 * Vote for [Popular Feature Requests](https://github.com/katalon-analytics/katalon-analytics/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc).
 * File a bug in [GitHub Issues](https://github.com/katalon-analytics/katalon-analytics/issues).
 
-### Katalon Studio
+## Katalon Studio
+
 [Katalon Studio](https://www.katalon.com) is a free and complete automation testing solution for Web, Mobile, and API testing with modern methodologies (Data-Driven Testing, TDD/BDD, Page Object Model, etc.) as well as advanced integration (JIRA, qTest, Slack, CI, Katalon TestOps, etc.). Learn more about [Katalon Studio features](https://www.katalon.com/features/).
+
+# Update **Table of Content** section in the README file
+
+> Python3 is required
+
+The **Table of Content** section at the top of the README file can be updated with the below code snippet
+
+```shell script
+python3 -m venv /tmp/venv/; /tmp/venv/bin/pip install md-toc==8.1.9
+/tmp/venv/bin/md_toc -p github ./README.md
+```

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.katalon</groupId>
 	<artifactId>katalon-studio-jira-plugin</artifactId>
-	<version>1.0.25</version>
+	<version>1.0.26</version>
 
 	<packaging>bundle</packaging>
 
@@ -159,12 +159,18 @@
 					<instructions>
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId};singleton:=true</Bundle-SymbolicName>
 						<Bundle-Version>${project.version}</Bundle-Version>
-						<Import-Package></Import-Package>
-						<DynamicImport-Package>*</DynamicImport-Package>
-						<_noee>true</_noee>
-						<_nouse>true</_nouse>
 
-						<!-- Change your public package here -->
+						<!-- KS requires non-empty Import-Package attribute T_T -->
+						<Import-Package>java.lang</Import-Package>
+						<DynamicImport-Package>*</DynamicImport-Package>
+
+						<!--
+							The Require-Capability attribute is unavailable in MANIFEST.MF when "_noee = true" and
+							the plugin installation to KS fails with the error of missing Require-Capability. I have no idea
+							why it happens, but it works when "_noee = false"  ̄\_(ツ)_/ ̄
+						-->
+						<_noee>false</_noee>
+						<_nouse>true</_nouse>
 						<Export-Package>com.katalon.plugin.jira*</Export-Package>
 					</instructions>
 				</configuration>

--- a/src/main/java/com/katalon/plugin/jira/composer/constant/ComposerJiraIntegrationMessageConstant.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/constant/ComposerJiraIntegrationMessageConstant.java
@@ -151,4 +151,18 @@ public class ComposerJiraIntegrationMessageConstant extends NLS {
     public static String ERROR_CUSTOM_FIELD_NOT_FOUND;
 
     public static String ERROR_GET_JIRA_ISSUE_WITH_WRONG_TEST_CASE_INDEX;
+
+    public static String BTN_LINK_JIRA_ISSUE_LABEL;
+
+    public static String BTN_EDIT_JIRA_ISSUE_LINK_LABEL;
+
+    public static String BTN_REMOVE_JIRA_ISSUE_LINK_LABEL;
+
+    public static String TXT_JIRA_ISSUE_KEY_PLACEHOLDER;
+
+    public static String BTN_OVERRIDE_TEST_CASE_DESCRIPTION_LABEL;
+
+    public static String LBL_LINKING_JIRA_ISSUE_TEXT;
+
+    public static String LBL_JIRA_ISSUE_NOT_EXISTING_TEXT;
 }

--- a/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraIssueLinkDialog.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraIssueLinkDialog.java
@@ -1,0 +1,262 @@
+package com.katalon.plugin.jira.composer.testcase;
+
+import ch.qos.logback.classic.Logger;
+import com.katalon.plugin.jira.composer.JiraUIComponent;
+import com.katalon.plugin.jira.composer.constant.ComposerJiraIntegrationMessageConstant;
+import com.katalon.plugin.jira.composer.util.Theme;
+import com.katalon.plugin.jira.core.JiraIntegrationAuthenticationHandler;
+import com.katalon.plugin.jira.core.JiraIntegrationException;
+import com.katalon.plugin.jira.core.JiraInvalidURLException;
+import com.katalon.plugin.jira.core.entity.JiraIssue;
+import com.katalon.plugin.jira.core.setting.JiraIntegrationSettingStore;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.*;
+import org.slf4j.LoggerFactory;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class JiraIssueLinkDialog extends TitleAreaDialog implements JiraUIComponent {
+    public static class Result {
+        private final JiraIssue foundJiraIssue;
+        private final boolean testCaseDescriptionOverride;
+
+        public Result(JiraIssue jiraIssue, boolean testCaseDescriptionOverride) {
+            foundJiraIssue = jiraIssue;
+            this.testCaseDescriptionOverride = testCaseDescriptionOverride;
+        }
+
+        public JiraIssue getJiraIssue() {
+            return foundJiraIssue;
+        }
+
+        public boolean getTestCaseDescriptionOverride() {
+            return testCaseDescriptionOverride;
+        }
+    }
+
+    private final Logger logger = (Logger)LoggerFactory.getLogger(JiraIssueLinkDialog.class);
+
+    private final JiraIntegrationAuthenticationHandler jiraIntegrationAuthenticationHandler;
+    private final JiraIntegrationSettingStore jiraIntegrationSettingStore;
+
+    private Text txtJiraIssueKey;
+
+    private Label lblLoadingProgress;
+
+    private Text lblOperationError;
+
+    private final Optional<String> linkedIssueKey;
+
+    private Button btnOverrideTestCaseDescription;
+
+    private final Consumer<Result> informInputsCollected;
+
+    public JiraIssueLinkDialog(Shell parentShell, Consumer<Result> onOkButtonPressing, String linkedIssueKey) {
+        super(parentShell);
+        jiraIntegrationAuthenticationHandler = new JiraIntegrationAuthenticationHandler();
+        informInputsCollected = onOkButtonPressing;
+        this.linkedIssueKey = StringUtils.isBlank(linkedIssueKey) ? Optional.empty() : Optional.of(linkedIssueKey);
+        jiraIntegrationSettingStore = getSettingStore();
+    }
+
+    @Override
+    protected Control createDialogArea(Composite parent) {
+        setMessage(ComposerJiraIntegrationMessageConstant.DIA_MESSAGE_LINK_TO_EXISTING_ISSUE, IMessageProvider.INFORMATION);
+        setTitle(getDialogTitle());
+
+        Composite composite = (Composite) super.createDialogArea(parent);
+        Composite mainComposite = new Composite(composite, SWT.NONE);
+        mainComposite.setLayout(GridLayoutFactory.fillDefaults().numColumns(2).margins(10, 10).spacing(10, SWT.DEFAULT).create());
+        mainComposite.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
+
+        Label lblLinkJIRAIssue = new Label(mainComposite, SWT.NONE);
+        lblLinkJIRAIssue.setLayoutData(GridDataFactory.fillDefaults().align(SWT.RIGHT, SWT.TOP).create());
+        lblLinkJIRAIssue.setText(ComposerJiraIntegrationMessageConstant.DIA_LBL_LINK_TO_EXISTING_ISSUE);
+
+        Composite jiraIssueKeyContainer = new Composite(mainComposite, SWT.NONE);
+        jiraIssueKeyContainer.setLayout(GridLayoutFactory.fillDefaults().numColumns(1).spacing(SWT.DEFAULT, 8).create());
+        jiraIssueKeyContainer.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
+
+        txtJiraIssueKey = new Text(jiraIssueKeyContainer, SWT.BORDER);
+        txtJiraIssueKey.setMessage(ComposerJiraIntegrationMessageConstant.TXT_JIRA_ISSUE_KEY_PLACEHOLDER);
+        txtJiraIssueKey.setLayoutData(
+                GridDataFactory.fillDefaults().hint(200, SWT.DEFAULT).align(SWT.LEFT, SWT.TOP).create());
+
+        btnOverrideTestCaseDescription = new Button(jiraIssueKeyContainer, SWT.CHECK);
+        btnOverrideTestCaseDescription.setText(ComposerJiraIntegrationMessageConstant.BTN_OVERRIDE_TEST_CASE_DESCRIPTION_LABEL);
+        btnOverrideTestCaseDescription.setLayoutData(GridDataFactory.fillDefaults().create());
+
+        lblLoadingProgress = new Label(jiraIssueKeyContainer, SWT.NONE);
+        lblLoadingProgress.setForeground(Theme.getSecondaryColor());
+        lblLoadingProgress.setText(ComposerJiraIntegrationMessageConstant.LBL_LINKING_JIRA_ISSUE_TEXT);
+        lblLoadingProgress.setLayoutData(
+                GridDataFactory.fillDefaults().align(SWT.LEFT, SWT.CENTER).create());
+
+        // The Label doesn't support wrapping text
+        lblOperationError = new Text(jiraIssueKeyContainer, SWT.READ_ONLY | SWT.MULTI | SWT.WRAP);
+        lblOperationError.setForeground(Theme.getErrorColor());
+        lblOperationError.setBackground(parent.getBackground());
+        lblOperationError.setLayoutData(
+                GridDataFactory.fillDefaults()
+                        .hint(getInitialSize().x, SWT.DEFAULT)
+                        .align(SWT.FILL, SWT.CENTER).grab(true, false).create());
+
+        toggleLoading(false);
+        hideError();
+        populateUiControls();
+        registerControlEvents();
+
+        return composite;
+    }
+
+    @Override
+    protected void configureShell(Shell shell) {
+        super.configureShell(shell);
+        shell.setText(getDialogTitle());
+    }
+
+    @Override
+    protected void createButtonsForButtonBar(Composite parent) {
+        super.createButtonsForButtonBar(parent);
+        getButton(OK).setEnabled(linkedIssueKey.isPresent());
+    }
+
+    @Override
+    protected void okPressed() {
+        final String issueKey = getSanitizedJiraIssueKeyInput();
+        final boolean overrideTestCaseDescription = btnOverrideTestCaseDescription.getSelection();
+
+        // This method is executed in the UI thread so changes in the UI that we want to do in this method
+        // (like hiding the label) won't be reflected until the method is finished. So a simple solution is to
+        // run the actual processing in another thread so the UI thread can update the UI.
+        Job job = new Job(String.format("Job %s.okPress()", getClass().getName())) {
+            @Override
+            protected IStatus run(IProgressMonitor iProgressMonitor) {
+                return asyncHandleOkButtonClick(iProgressMonitor, issueKey, overrideTestCaseDescription);
+            }
+        };
+
+        job.setPriority(Job.INTERACTIVE);
+        job.setSystem(true);
+        job.schedule();
+   }
+
+    private void populateUiControls() {
+        linkedIssueKey.ifPresent(txtJiraIssueKey::setText);
+        btnOverrideTestCaseDescription.setSelection(jiraIntegrationSettingStore.getTestCaseDescriptionJiraIssueOverridden());
+    }
+
+    private void toggleLoading(boolean visible) {
+        lblLoadingProgress.setVisible(visible);
+        if (lblLoadingProgress.getLayoutData() instanceof GridData) {
+            ((GridData) lblLoadingProgress.getLayoutData()).exclude = !lblLoadingProgress.getVisible();
+        }
+
+        txtJiraIssueKey.setEnabled(!visible);
+        btnOverrideTestCaseDescription.setEnabled(!visible);
+
+        // One of caller of this method is the event of rendering the
+        // dialog content when the buttons are not yet created.
+        Optional.ofNullable(getButton(OK)).ifPresent(b -> b.setEnabled(!visible));
+        Optional.ofNullable(getButton(CANCEL)).ifPresent(b -> b.setEnabled(!visible));
+        reLayout(lblLoadingProgress.getParent());
+    }
+
+    private void showError(String text) {
+        lblOperationError.setVisible(true);
+        lblOperationError.setText(text);
+        if (lblOperationError.getLayoutData() instanceof GridData) {
+            ((GridData) lblOperationError.getLayoutData()).exclude = !lblOperationError.getVisible();
+        }
+
+        reLayout(lblOperationError.getParent());
+    }
+
+    private void hideError() {
+        lblOperationError.setVisible(false);
+        if (lblOperationError.getLayoutData() instanceof GridData) {
+            ((GridData) lblOperationError.getLayoutData()).exclude = !lblOperationError.getVisible();
+        }
+
+        reLayout(lblOperationError.getParent());
+    }
+
+    private void registerControlEvents() {
+        txtJiraIssueKey.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent e) {
+                getButton(OK).setEnabled(StringUtils.isNotBlank(getSanitizedJiraIssueKeyInput()));
+            }
+        });
+    }
+
+    private String getDialogTitle() {
+        return ComposerJiraIntegrationMessageConstant.DIA_TITLE_LINK_TO_EXISTING_ISSUE;
+    }
+
+    private String getSanitizedJiraIssueKeyInput() {
+        return StringUtils.strip(txtJiraIssueKey.getText());
+    }
+
+    private void reLayout(Composite container) {
+        container.layout();
+        container.pack();
+    }
+
+    private IStatus asyncHandleOkButtonClick(IProgressMonitor iProgressMonitor, String issueKey, boolean overrideTestCaseDescription) {
+        Display display = getShell().getDisplay();
+        try {
+            display.syncExec(() -> {
+                hideError();
+                toggleLoading(true);
+            });
+
+            final JiraIssue issue = jiraIntegrationAuthenticationHandler.getJiraIssue(getCredential(), issueKey);
+            display.syncExec(() -> informInputsCollected.accept(new Result(issue, overrideTestCaseDescription)));
+
+            // Only persists when the processing in the caller side is successful
+            jiraIntegrationSettingStore.setTestCaseDescriptionJiraIssueOverridden(overrideTestCaseDescription);
+
+            // We want to end before the dialog is closed to ensure that any code that
+            // depends on the dialog being open can still access it.
+            display.asyncExec(super::okPressed);
+        }
+        catch (Exception e) {
+            display.syncExec(() -> toggleLoading(false));
+            logger.error("Error on invoking the handler for JIRA Issue key", e);
+
+            if (e instanceof JiraInvalidURLException) {
+                display.syncExec(() -> showError(ComposerJiraIntegrationMessageConstant.LBL_JIRA_ISSUE_NOT_EXISTING_TEXT));
+            }
+            else {
+                String displayMessage = e.getMessage();
+                if (e instanceof RuntimeException) {
+                    // threw by the invocation from Consumer<JiraIssueLinkDialog. Result>
+                    if (e.getCause() instanceof JiraIntegrationException) {
+                        displayMessage = String.format("Error on linking the test case to JIRA issue key %s: %s", issueKey, e.getCause().getMessage());
+                    }
+                }
+
+                final String m = displayMessage;
+                display.syncExec(() -> showError(m));
+            }
+        }
+        finally {
+            iProgressMonitor.done();
+        }
+
+        return Status.OK_STATUS;
+    }
+}

--- a/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
@@ -1,22 +1,5 @@
 package com.katalon.plugin.jira.composer.testcase;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
-
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.MouseAdapter;
-import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.program.Program;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Link;
-import org.slf4j.LoggerFactory;
-
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.katalon.platform.api.extension.TestCaseIntegrationViewDescription.PartActionService;
 import com.katalon.platform.api.extension.TestCaseIntegrationViewDescription.TestCaseIntegrationView;
@@ -25,92 +8,164 @@ import com.katalon.plugin.jira.composer.JiraUIComponent;
 import com.katalon.plugin.jira.composer.constant.ComposerJiraIntegrationMessageConstant;
 import com.katalon.plugin.jira.composer.constant.StringConstants;
 import com.katalon.plugin.jira.composer.util.ControlUtil;
+import com.katalon.plugin.jira.core.JiraCredential;
+import com.katalon.plugin.jira.core.JiraIntegrationAuthenticationHandler;
+import com.katalon.plugin.jira.core.JiraIntegrationException;
 import com.katalon.plugin.jira.core.JiraObjectToEntityConverter;
 import com.katalon.plugin.jira.core.entity.JiraIssue;
-
+import com.katalon.plugin.jira.core.issue.UpdateTestCaseIssueDescription;
+import com.katalon.plugin.jira.core.setting.JiraIntegrationSettingStore;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.program.Program;
+import org.eclipse.swt.widgets.*;
 import ch.qos.logback.classic.Logger;
+import org.slf4j.LoggerFactory;
+import org.eclipse.jface.layout.GridDataFactory;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.util.Objects;
+import java.util.Optional;
 
 public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseIntegrationView {
-    
-    private Logger logger = (Logger) LoggerFactory.getLogger(JiraTestCaseIntegrationView.class);
+    private final Logger logger = (Logger)LoggerFactory.getLogger(JiraTestCaseIntegrationView.class);
 
-    private Composite container;
+    private  Composite container;
 
     private Link lblDisplayKey;
+    private Label lblDisplaySummary;
+    private Label lblDisplayStatus;
+    private Label lblDisplayDiscription;
 
-    private Label lblDisplaySummary, lblDisplayStatus, lblDisplayDiscription;
+    private Optional<JiraIssue> linkedJiraIssue;
+    private JiraIntegrationAuthenticationHandler authenticationHandler;
 
-    private JiraIssue jiraIssue;
+    private TestCaseEntity testCaseModel;
+
+    private Button btnLinkJiraIssue;
+
+    private Button btnEditJiraIssueLink;
 
     @Override
     public Control onCreateView(Composite parent, PartActionService partActionService, TestCaseEntity testCaseEntity) {
-        jiraIssue = JiraObjectToEntityConverter.getJiraIssue(testCaseEntity);
+        testCaseModel = testCaseEntity;
+        loadJiraIssueLink();
+        authenticationHandler = new JiraIntegrationAuthenticationHandler();
 
         container = new Composite(parent, SWT.BORDER);
         container.setBackground(parent.getDisplay().getSystemColor(SWT.COLOR_WHITE));
         container.setBackgroundMode(SWT.INHERIT_FORCE);
-        GridLayout gridLayout = new GridLayout(2, false);
-        gridLayout.verticalSpacing = 10;
-        gridLayout.horizontalSpacing = 15;
-        container.setLayout(gridLayout);
+        container.setLayout(GridLayoutFactory.fillDefaults().numColumns(2).spacing(15, 10).create());
 
         Label lblKey = new Label(container, SWT.NONE);
-        lblKey.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false, 1, 1));
+        lblKey.setLayoutData(GridDataFactory.fillDefaults().align(SWT.LEFT, SWT.CENTER).create());
         lblKey.setText(ComposerJiraIntegrationMessageConstant.VIEW_LBL_KEY);
 
-        lblDisplayKey = new Link(container, SWT.NONE);
-        lblDisplayKey.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));
+        Composite displayKeyContainer = new Composite(container, SWT.NONE);
+        displayKeyContainer.setLayout(GridLayoutFactory.fillDefaults().numColumns(3).spacing(1, 1).create());
+        displayKeyContainer.setLayoutData(GridDataFactory.fillDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).create());
+        lblDisplayKey = new Link(displayKeyContainer, SWT.NONE);
         lblDisplayKey.setToolTipText(ComposerJiraIntegrationMessageConstant.VIEW_TOOLTIP_VIEW_ISSUE_ON_JIRA);
+        lblDisplayKey.setLayoutData(GridDataFactory.fillDefaults().align(SWT.CENTER, SWT.CENTER).create());
+
+        btnLinkJiraIssue = new Button(displayKeyContainer, SWT.PUSH);
+        btnLinkJiraIssue.setData(ControlUtil.IGNORE_SET_ENABLED_DATA_KEY, Boolean.TRUE);
+        btnLinkJiraIssue.setText(ComposerJiraIntegrationMessageConstant.BTN_LINK_JIRA_ISSUE_LABEL);
+        btnLinkJiraIssue.setLayoutData(GridDataFactory.fillDefaults().align(SWT.CENTER, SWT.CENTER).create());
+
+        btnEditJiraIssueLink = new Button(displayKeyContainer, SWT.PUSH);
+        btnEditJiraIssueLink.setText(ComposerJiraIntegrationMessageConstant.BTN_EDIT_JIRA_ISSUE_LINK_LABEL);
+        btnEditJiraIssueLink.setLayoutData(GridDataFactory.fillDefaults().align(SWT.CENTER, SWT.CENTER).create());
 
         Label lblSummary = new Label(container, SWT.NONE);
-        lblSummary.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false, 1, 1));
+        lblSummary.setLayoutData(GridDataFactory.fillDefaults().align(SWT.LEFT, SWT.TOP).create());
         lblSummary.setText(StringConstants.SUMMARY);
 
         lblDisplaySummary = new Label(container, SWT.WRAP);
-        lblDisplaySummary.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+        lblDisplaySummary.setLayoutData(GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).create());
 
         Label lblStatus = new Label(container, SWT.NONE);
-        lblStatus.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false, 1, 1));
+        lblStatus.setLayoutData(GridDataFactory.fillDefaults().align(SWT.LEFT, SWT.TOP).create());
         lblStatus.setText(StringConstants.STATUS);
 
         lblDisplayStatus = new Label(container, SWT.NONE);
-        lblDisplayStatus.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+        lblDisplayStatus.setLayoutData(GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).create());
 
         Label lblDescription = new Label(container, SWT.NONE);
-        lblDescription.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false, 1, 1));
+        lblDescription.setLayoutData(GridDataFactory.fillDefaults().align(SWT.LEFT, SWT.TOP).create());
         lblDescription.setText(StringConstants.DESCRIPTION);
 
         lblDisplayDiscription = new Label(container, SWT.WRAP);
-        lblDisplayDiscription.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+        lblDisplayDiscription.setLayoutData(GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).create());
 
-        setInput();
-
-        registerControlListeners();
+        registerControlEvents();
+        renderTestCase();
 
         return container;
     }
 
-    private void registerControlListeners() {
+    private void changeUiControlVisibilityWithJiraIssueLinkStage() {
+        boolean jiraIssueLinked = linkedJiraIssue.isPresent();
+        setControlVisibility(lblDisplayKey, jiraIssueLinked);
+        setControlVisibility(btnLinkJiraIssue, !jiraIssueLinked);
+        setControlVisibility(btnEditJiraIssueLink, jiraIssueLinked);
+    }
+
+    private void setControlVisibility(Control control, boolean visible) {
+        control.setVisible(visible);
+        Object layoutDataRaw = control.getLayoutData();
+        if (Objects.nonNull(layoutDataRaw) && layoutDataRaw instanceof GridData) {
+            ((GridData) layoutDataRaw).exclude = !visible;
+        }
+    }
+
+    private void registerControlEvents() {
         lblDisplayKey.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseDown(MouseEvent e) {
-                try {
-                    Program.launch(getHTMLLink(jiraIssue).toURL().toString());
-                } catch (IOException | URISyntaxException | GeneralSecurityException ex) {
-                    logger.error("", e);
-                }
+                linkedJiraIssue.ifPresent(jiraIssue -> {
+                    try {
+                        Program.launch(getHTMLLink(jiraIssue).toURL().toString());
+                    } catch (IOException | URISyntaxException | GeneralSecurityException ex) {
+                        logger.error("Fail to launch the app to handle the URL of the JIRA Issue ", ex);
+                    }
+                });
+            }
+        });
+
+        btnLinkJiraIssue.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                JiraIssueLinkDialog dialog = new JiraIssueLinkDialog(btnLinkJiraIssue.getShell(), JiraTestCaseIntegrationView.this::onLinkingToJiraIssue, null);
+                dialog.open();
+            }
+        });
+
+        btnEditJiraIssueLink.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                JiraIssueLinkDialog dialog = new JiraIssueLinkDialog(
+                        btnLinkJiraIssue.getShell(), JiraTestCaseIntegrationView.this::onLinkingToJiraIssue,
+                        linkedJiraIssue.map(JiraIssue::getKey).orElse(StringUtils.EMPTY));
+                dialog.open();
             }
         });
     }
 
-    private void setInput() {
-        if (jiraIssue == null) {
-            ControlUtil.recursiveSetEnabled(container, false);
-            return;
-        }
-        lblDisplayKey.setText("<a>" + jiraIssue.getKey() + "</a>");
+    private void populateJiraFieldValues() {
+        ControlUtil.recursiveSetEnabled(container, linkedJiraIssue.isPresent());
 
-        Issue fields = jiraIssue.getFields();
+        JiraIssue issue = linkedJiraIssue.get();
+        lblDisplayKey.setText("<a>" + issue.getKey() + "</a>");
+
+        Issue fields = issue.getFields();
         lblDisplaySummary.setText(StringUtils.defaultString(fields.getSummary()));
         lblDisplayStatus.setText(StringUtils.defaultString(fields.getStatus().getName()));
         lblDisplayDiscription.setText(StringUtils.defaultString(fields.getDescription()));
@@ -122,5 +177,52 @@ public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseInt
 
     public String getDocumentationUrl() {
         return ComposerJiraIntegrationMessageConstant.URL_TEST_CASE_INTEGRATION_JIRA;
+    }
+
+    private void onLinkingToJiraIssue(JiraIssueLinkDialog.Result dialogResult) {
+        try {
+            JiraCredential credential = getCredential();
+            JiraIntegrationSettingStore settingStore = getSettingStore();
+            JiraIssue issue = dialogResult.getJiraIssue();
+            testCaseModel = JiraObjectToEntityConverter.updateTestCaseJiraIssueLink(issue, testCaseModel);
+            UpdateTestCaseIssueDescription updateDescription = UpdateTestCaseIssueDescription.Builder.create()
+                    .setTestCase(testCaseModel)
+                    .setIssue(issue)
+                    .setJiraCredential(credential)
+                    .setSettingStore(settingStore)
+                    .setOverrideTestCaseDescriptionFromIssue(dialogResult.getTestCaseDescriptionOverride())
+                    .setKatalonCommentField(authenticationHandler.getKatalonCommentField(credential, settingStore))
+                    .build();
+            testCaseModel = JiraObjectToEntityConverter.updateTestCase(testCaseModel, updateDescription);
+        }
+        catch (JiraIntegrationException | IOException e) {
+            // Turn checked exception to unchecked one to comply
+            // with the Consumer interface
+            throw new RuntimeException(e);
+        }
+
+        // Reload the UI to reflect the test case has been linked to JIRA issue
+        loadJiraIssueLink();
+        renderTestCase();
+    }
+
+    private void loadJiraIssueLink() {
+        linkedJiraIssue = Optional.ofNullable(JiraObjectToEntityConverter.getJiraIssue(testCaseModel));
+    }
+
+    private void redrawJiraIssueKeyColumn() {
+        Composite parent = lblDisplayKey.getParent();
+        if (!linkedJiraIssue.isPresent()) {
+            parent = btnLinkJiraIssue.getParent();
+        }
+
+        parent.layout();
+        parent.pack();
+    }
+
+    private void renderTestCase() {
+        changeUiControlVisibilityWithJiraIssueLinkStage();
+        populateJiraFieldValues();
+        redrawJiraIssueKeyColumn();
     }
 }

--- a/src/main/java/com/katalon/plugin/jira/composer/util/ControlUtil.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/util/ControlUtil.java
@@ -3,16 +3,28 @@ package com.katalon.plugin.jira.composer.util;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import java.util.Objects;
+
 public class ControlUtil {
+    // A key for the flag to ignore the object org.eclipse.swt.widgets.Widget when the method recursiveSetEnabled() proceeds them
+    // Because the key is a flag, so non-null value (whatever type) is true and otherwise is false
+    public static final String IGNORE_SET_ENABLED_DATA_KEY = "ignoreSetEnabled";
+
     public static void recursiveSetEnabled(Control ctrl, boolean enabled) {
         if (ctrl instanceof Composite) {
             Composite comp = (Composite) ctrl;
             for (Control c : comp.getChildren()) {
-                recursiveSetEnabled(c, enabled);
-                c.setEnabled(enabled);
+                if (c instanceof Composite) {
+                    recursiveSetEnabled(c, enabled);
+                }
+                else if (Objects.isNull(c.getData(IGNORE_SET_ENABLED_DATA_KEY))) {
+                    c.setEnabled(enabled);
+                }
             }
         } else {
-            ctrl.setEnabled(enabled);
+            if (Objects.isNull(ctrl.getData(IGNORE_SET_ENABLED_DATA_KEY))) {
+                ctrl.setEnabled(enabled);
+            }
         }
     }
 }

--- a/src/main/java/com/katalon/plugin/jira/composer/util/Theme.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/util/Theme.java
@@ -1,0 +1,15 @@
+package com.katalon.plugin.jira.composer.util;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.SWT;
+
+public class Theme {
+    public static Color getSecondaryColor() {
+        return Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GREEN);
+    }
+
+    public static Color getErrorColor() {
+        return Display.getCurrent().getSystemColor(SWT.COLOR_RED);
+    }
+}

--- a/src/main/java/com/katalon/plugin/jira/core/JiraCredential.java
+++ b/src/main/java/com/katalon/plugin/jira/core/JiraCredential.java
@@ -1,5 +1,7 @@
 package com.katalon.plugin.jira.core;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class JiraCredential {
     private String serverUrl;
 
@@ -29,5 +31,13 @@ public class JiraCredential {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public boolean isJiraCloud() {
+        if (StringUtils.isEmpty(serverUrl)) {
+            throw new IllegalStateException("The server URL is empty");
+        }
+
+        return serverUrl.contains(".atlassian.net") || serverUrl.contains(".jira.com");
     }
 }

--- a/src/main/java/com/katalon/plugin/jira/core/JiraObjectToEntityConverter.java
+++ b/src/main/java/com/katalon/plugin/jira/core/JiraObjectToEntityConverter.java
@@ -1,8 +1,5 @@
 package com.katalon.plugin.jira.core;
 
-import java.util.Map;
-import java.util.Optional;
-
 import com.katalon.platform.api.controller.ReportController;
 import com.katalon.platform.api.controller.TestCaseController;
 import com.katalon.platform.api.exception.ResourceException;
@@ -11,13 +8,12 @@ import com.katalon.platform.api.model.Integration;
 import com.katalon.platform.api.model.ReportEntity;
 import com.katalon.platform.api.model.TestCaseEntity;
 import com.katalon.plugin.jira.core.constant.StringConstants;
-import com.katalon.plugin.jira.core.entity.JiraIntegratedIssue;
-import com.katalon.plugin.jira.core.entity.JiraIntegratedObject;
-import com.katalon.plugin.jira.core.entity.JiraIssue;
-import com.katalon.plugin.jira.core.entity.JiraIssueCollection;
-import com.katalon.plugin.jira.core.entity.JiraReport;
+import com.katalon.plugin.jira.core.entity.*;
 import com.katalon.plugin.jira.core.util.JsonUtil;
 import com.katalon.plugin.jira.core.util.PlatformUtil;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class JiraObjectToEntityConverter {
     private static <T extends JiraIntegratedObject> Optional<T> getJiraObject(HasIntegration entity, Class<T> clazz) {
@@ -25,6 +21,7 @@ public class JiraObjectToEntityConverter {
         if (integratedEntity == null) {
             return Optional.empty();
         }
+
         return Optional.of((T) JsonUtil
                 .fromJson(integratedEntity.getProperties().get(StringConstants.INTEGRATED_VALUE_NAME), clazz));
     }
@@ -42,7 +39,17 @@ public class JiraObjectToEntityConverter {
                 .orElse(null);
     }
 
-    public static TestCaseEntity updateTestCase(JiraIssue issue, TestCaseEntity testCase)
+    public static TestCaseEntity updateTestCase(TestCaseEntity testCase, TestCaseController.UpdateDescription updateDescription)
+            throws JiraIntegrationException {
+        try {
+            return PlatformUtil.getPlatformController(TestCaseController.class)
+                    .updateTestCase(PlatformUtil.getCurrentProject(), testCase, updateDescription);
+        } catch (ResourceException e) {
+            throw new JiraIntegrationException(e);
+        }
+    }
+
+    public static TestCaseEntity updateTestCaseJiraIssueLink(JiraIssue issue, TestCaseEntity testCase)
             throws JiraIntegrationException {
         Integration jiraIntegratedEntity = new Integration() {
 

--- a/src/main/java/com/katalon/plugin/jira/core/constant/StringConstants.java
+++ b/src/main/java/com/katalon/plugin/jira/core/constant/StringConstants.java
@@ -39,6 +39,8 @@ public class StringConstants {
 
     public static final String PREF_INTEGRATION_ENABLED = "integration.enabled";
 
+    public static final String PREF_TEST_CASE_DESCRIPTION_JIRA_ISSUE_OVERRIDDEN = "integration.testCaseDescriptionJiraIssueOverridden";
+
     public static final String INTEGRATED_VALUE_NAME = "integratedValue";
 
     public static final String HREF_DASHBOARD = "/secure/Dashboard.jspa";
@@ -61,5 +63,6 @@ public class StringConstants {
     
     public static final String HREF_DEFAULT_DASHBOARD = "/jira/dashboards/last-visited";
 
+    // The ID of custom field in JIRA created by https://marketplace.atlassian.com/apps/1217501/katalon-test-automation-for-jira?hosting=cloud&tab=overview
     public static final String KATALON_CUSTOM_FIELD_ID = "com.katalon.katalon-jira-plugin:com.katalon.jiraplugin.gherkin";
 }

--- a/src/main/java/com/katalon/plugin/jira/core/issue/NewTestCaseIssueDescription.java
+++ b/src/main/java/com/katalon/plugin/jira/core/issue/NewTestCaseIssueDescription.java
@@ -1,0 +1,80 @@
+package com.katalon.plugin.jira.core.issue;
+
+import com.atlassian.jira.rest.client.api.domain.Field;
+import com.katalon.platform.api.controller.TestCaseController;
+import com.katalon.plugin.jira.core.JiraCredential;
+import com.katalon.plugin.jira.core.entity.JiraIssue;
+import com.katalon.plugin.jira.core.setting.JiraIntegrationSettingStore;
+
+import java.util.Optional;
+
+public class NewTestCaseIssueDescription extends TestCaseIssueProxyDescription implements TestCaseController.NewDescription {
+    public static class Builder {
+        private String testCaseName;
+        private JiraIssue issue;
+        private JiraCredential jiraCredential;
+        private JiraIntegrationSettingStore settingStore;
+        private Optional<Field> katalonCommentField;
+
+        public static Builder create() {
+            return new Builder();
+        }
+
+        public Builder setTestCaseName(String testCaseName) {
+            this.testCaseName = testCaseName;
+            return this;
+        }
+
+        public Builder setIssue(JiraIssue issue) {
+            this.issue = issue;
+            return this;
+        }
+
+        public Builder setJiraCredential(JiraCredential jiraCredential) {
+            this.jiraCredential = jiraCredential;
+            return this;
+        }
+
+        public Builder setSettingStore(JiraIntegrationSettingStore settingStore) {
+            this.settingStore = settingStore;
+            return this;
+        }
+
+        public Builder setKatalonCommentField(Optional<Field> katalonCommentField) {
+            this.katalonCommentField = katalonCommentField;
+            return this;
+        }
+
+        public NewTestCaseIssueDescription build()  {
+            return new NewTestCaseIssueDescription(jiraCredential, issue, settingStore, katalonCommentField, testCaseName);
+        }
+    }
+
+    private final String testCaseName;
+
+
+    public NewTestCaseIssueDescription(JiraCredential jiraCredential, JiraIssue linkedJiraIssue, JiraIntegrationSettingStore settingStore, Optional<Field> katalonCommentField, String testCaseName) {
+        super(jiraCredential, linkedJiraIssue, settingStore, katalonCommentField);
+        this.testCaseName = testCaseName;
+    }
+
+    @Override
+    public String getName() {
+        return testCaseName;
+    }
+
+    @Override
+    public String getDescription() {
+        return getTestCaseDescriptionFromJiraIssue();
+    }
+
+    @Override
+    public String getComment() {
+        return getTestCaseComment();
+    }
+
+    @Override
+    public String getTag() {
+        return JIRA_INTEGRATION_TEST_CASE_TAG_VALUE;
+    }
+}

--- a/src/main/java/com/katalon/plugin/jira/core/issue/TestCaseIssueProxyDescription.java
+++ b/src/main/java/com/katalon/plugin/jira/core/issue/TestCaseIssueProxyDescription.java
@@ -1,0 +1,99 @@
+package com.katalon.plugin.jira.core.issue;
+
+import com.atlassian.jira.rest.client.api.domain.Field;
+import com.katalon.plugin.jira.composer.constant.StringConstants;
+import com.katalon.plugin.jira.core.JiraCredential;
+import com.katalon.plugin.jira.core.entity.ImprovedIssue;
+import com.katalon.plugin.jira.core.entity.JiraIssue;
+import com.katalon.plugin.jira.core.setting.JiraIntegrationSettingStore;
+import org.apache.commons.lang3.StringUtils;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A base class for concrete implementation of com.katalon.platform.api.controller.TestCaseController.NewDescription and
+ * TestCaseController.NewDescription where the concrete implementation is for creating/changing the object of
+ * com.katalon.platform.api.model.TestCaseEntity along with the linked com.katalon.plugin.jira.core.entity.JiraIssue
+ */
+public abstract class TestCaseIssueProxyDescription {
+    private static class TestCaseCommentBag {
+        private final Field katalonCommentField;
+        private final ImprovedIssue jiraImprovedIssue;
+
+        public TestCaseCommentBag(Field katalonCommentField, ImprovedIssue jiraImprovedIssue) {
+            this.katalonCommentField = katalonCommentField;
+            this.jiraImprovedIssue = jiraImprovedIssue;
+        }
+
+        public Field getKatalonCommentField() {
+            return katalonCommentField;
+        }
+
+        public ImprovedIssue getJiraImprovedIssue() {
+            return jiraImprovedIssue;
+        }
+    }
+
+    protected static final String JIRA_INTEGRATION_TEST_CASE_TAG_VALUE = "jira-integration";
+
+    protected final JiraCredential jiraCredential;
+    protected final JiraIssue linkedJiraIssue;
+    protected final JiraIntegrationSettingStore settingStore;
+    protected final Optional<Field> katalonCommentField;
+
+    protected TestCaseIssueProxyDescription(JiraCredential jiraCredential, JiraIssue linkedJiraIssue, JiraIntegrationSettingStore settingStore, Optional<Field> katalonCommentField) {
+        if (Objects.isNull(katalonCommentField)) {
+            throw new IllegalArgumentException("The katalonCommentField field must not be null.");
+        }
+
+        if (Objects.isNull(linkedJiraIssue)) {
+            throw new IllegalArgumentException("The linkedJiraIssue field must not be null.");
+        }
+
+        this.jiraCredential = jiraCredential;
+        this.linkedJiraIssue = linkedJiraIssue;
+        this.settingStore = settingStore;
+        this.katalonCommentField = katalonCommentField;
+    }
+
+    private Optional<TestCaseCommentBag> getKatalonTestCaseComment() {
+        if (!katalonCommentField.isPresent()) {
+            return Optional.empty();
+        }
+
+        ImprovedIssue fields = linkedJiraIssue.getFields();
+        if (Objects.isNull(fields)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new TestCaseCommentBag(katalonCommentField.get(), fields));
+    }
+
+    protected String getTestCaseComment() {
+        return getKatalonTestCaseComment().map(testCaseCommentBag -> {
+            Map<String, Object> customFields = testCaseCommentBag.getJiraImprovedIssue().getCustomFields();
+            String customFieldId = testCaseCommentBag.getKatalonCommentField().getId();
+            Object jsonCommentValue = customFields.get(customFieldId);
+
+            return Objects.nonNull(jsonCommentValue) ? jsonCommentValue.toString() : StringUtils.EMPTY;
+        }).orElse(StringUtils.EMPTY);
+    }
+
+    protected String getTestCaseDescriptionFromJiraIssue() {
+        return String.format("%1$s: %2$s%n%3$s: %4$s",
+                StringConstants.SUMMARY,
+                StringUtils.defaultString(linkedJiraIssue.getFields().getSummary()),
+                StringConstants.DESCRIPTION,
+                StringUtils.defaultString(linkedJiraIssue.getFields().getDescription()));
+    }
+
+    public Optional<Boolean> isKatalonCommentFieldPresentInJiraIssue() {
+        return getKatalonTestCaseComment().map(testCaseCommentBag -> {
+            Map<String, Object> customFields = testCaseCommentBag.getJiraImprovedIssue().getCustomFields();
+            String customFieldId = testCaseCommentBag.getKatalonCommentField().getId();
+
+            return customFields.containsKey(customFieldId);
+        });
+    }
+}

--- a/src/main/java/com/katalon/plugin/jira/core/issue/UpdateTestCaseIssueDescription.java
+++ b/src/main/java/com/katalon/plugin/jira/core/issue/UpdateTestCaseIssueDescription.java
@@ -1,0 +1,84 @@
+package com.katalon.plugin.jira.core.issue;
+
+import com.atlassian.jira.rest.client.api.domain.Field;
+import com.katalon.platform.api.controller.TestCaseController;
+import com.katalon.platform.api.model.TestCaseEntity;
+import com.katalon.plugin.jira.core.JiraCredential;
+import com.katalon.plugin.jira.core.entity.JiraIssue;
+import com.katalon.plugin.jira.core.setting.JiraIntegrationSettingStore;
+
+import java.util.Optional;
+
+public class UpdateTestCaseIssueDescription extends TestCaseIssueProxyDescription implements TestCaseController.UpdateDescription {
+    public static class Builder {
+        private TestCaseEntity testCase;
+        private JiraIssue issue;
+        private JiraCredential jiraCredential;
+        private JiraIntegrationSettingStore settingStore;
+        private boolean overrideTestCaseDescriptionFromIssue = false;
+        private Optional<Field> katalonCommentField;
+
+        public static UpdateTestCaseIssueDescription.Builder create() {
+            return new UpdateTestCaseIssueDescription.Builder();
+        }
+
+        public UpdateTestCaseIssueDescription.Builder setTestCase(TestCaseEntity testCase) {
+            this.testCase = testCase;
+            return this;
+        }
+
+        public UpdateTestCaseIssueDescription.Builder setIssue(JiraIssue issue) {
+            this.issue = issue;
+            return this;
+        }
+
+        public UpdateTestCaseIssueDescription.Builder setJiraCredential(JiraCredential jiraCredential) {
+            this.jiraCredential = jiraCredential;
+            return this;
+        }
+
+        public UpdateTestCaseIssueDescription.Builder setSettingStore(JiraIntegrationSettingStore settingStore) {
+            this.settingStore = settingStore;
+            return this;
+        }
+
+        public UpdateTestCaseIssueDescription.Builder setOverrideTestCaseDescriptionFromIssue(boolean overrideTestCaseDescriptionFromIssue) {
+            this.overrideTestCaseDescriptionFromIssue = overrideTestCaseDescriptionFromIssue;
+            return this;
+        }
+
+        public UpdateTestCaseIssueDescription.Builder setKatalonCommentField(Optional<Field> katalonCommentField) {
+            this.katalonCommentField = katalonCommentField;
+            return this;
+        }
+
+        public UpdateTestCaseIssueDescription build() {
+            return new UpdateTestCaseIssueDescription(jiraCredential, issue, settingStore, katalonCommentField, testCase, overrideTestCaseDescriptionFromIssue);
+        }
+    }
+
+    private final TestCaseEntity testCase;
+    private final boolean overrideTestCaseDescriptionFromIssue;
+
+    public UpdateTestCaseIssueDescription(JiraCredential jiraCredential, JiraIssue linkedJiraIssue, JiraIntegrationSettingStore settingStore, Optional<Field> katalonCommentField, TestCaseEntity testCase, boolean overrideTestCaseDescriptionFromIssue) {
+        super(jiraCredential, linkedJiraIssue, settingStore, katalonCommentField);
+
+        this.testCase = testCase;
+        this.overrideTestCaseDescriptionFromIssue = overrideTestCaseDescriptionFromIssue;
+    }
+
+    @Override
+    public String getDescription() {
+        return overrideTestCaseDescriptionFromIssue ? getTestCaseDescriptionFromJiraIssue() : testCase.getDescription();
+    }
+
+    @Override
+    public String getComment() {
+        return getTestCaseComment();
+    }
+
+    @Override
+    public String getTag() {
+        return JIRA_INTEGRATION_TEST_CASE_TAG_VALUE;
+    }
+}

--- a/src/main/java/com/katalon/plugin/jira/core/setting/JiraIntegrationSettingStore.java
+++ b/src/main/java/com/katalon/plugin/jira/core/setting/JiraIntegrationSettingStore.java
@@ -1,28 +1,5 @@
 package com.katalon.plugin.jira.core.setting;
 
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_AUTH_ENCRYPTION_ENABLED;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_AUTH_PASSWORD;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_AUTH_SERVER_URL;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_AUTH_USER;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_AUTH_USERNAME;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_AUTH_ENCRYPTION_MIGRATED;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_INTEGRATION_ENABLED;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_ATTACH_LOG;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_ATTACH_SCREENSHOT;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_JIRA_ISSUE_TYPE;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_JIRA_PROJECT;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_JIRA_CLOUD_FIELD;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_TEST_RESULT_AUTOMATICALLY;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_USE_TEST_CASE_NAME_AS_SUMMARY;
-import static com.katalon.plugin.jira.core.constant.StringConstants.MIGRATE_PROJECT_SCOPE;
-import static com.katalon.plugin.jira.core.constant.StringConstants.PREF_SUBMIT_FETCH_JIRA_CLOUD_CONTENT;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.security.GeneralSecurityException;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.atlassian.jira.rest.client.api.domain.User;
 import com.google.gson.reflect.TypeToken;
 import com.katalon.platform.api.exception.CryptoException;
@@ -35,6 +12,13 @@ import com.katalon.plugin.jira.core.entity.JiraField;
 import com.katalon.plugin.jira.core.entity.JiraIssueType;
 import com.katalon.plugin.jira.core.entity.JiraProject;
 import com.katalon.plugin.jira.core.util.JsonUtil;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.security.GeneralSecurityException;
+
+import static com.katalon.plugin.jira.core.constant.StringConstants.*;
 
 public class JiraIntegrationSettingStore {
 
@@ -50,6 +34,14 @@ public class JiraIntegrationSettingStore {
 
     public void enableIntegration(boolean enabled) throws IOException {
         delegate.setBoolean(PREF_INTEGRATION_ENABLED, enabled);
+    }
+
+    public boolean getTestCaseDescriptionJiraIssueOverridden() {
+        return delegate.getBoolean(PREF_TEST_CASE_DESCRIPTION_JIRA_ISSUE_OVERRIDDEN, false);
+    }
+
+    public void setTestCaseDescriptionJiraIssueOverridden(boolean overridden) {
+        delegate.setBoolean(PREF_TEST_CASE_DESCRIPTION_JIRA_ISSUE_OVERRIDDEN, overridden);
     }
 
     public String getUsername(boolean encryptionEnabled) throws IOException, GeneralSecurityException {

--- a/src/main/resources/com/katalon/plugin/jira/composer/constant/ComposerJiraIntegrationMessage.properties
+++ b/src/main/resources/com/katalon/plugin/jira/composer/constant/ComposerJiraIntegrationMessage.properties
@@ -65,3 +65,10 @@ DOCUMENT_URL_JIRA_CLOUD_FETCH_CONTENT=https://confluence.atlassian.com/jirakb/ho
 ERROR_UNABLE_TO_SAVE_JIRA_SETTING=Unable to save JIRA setting
 ERROR_CUSTOM_FIELD_NOT_FOUND=Custom field not found.\nThe custom field may have been removed. Please check again in your Jira Cloud Server and select a new custom field (if any) in Project > Settings > Plugins > Jira.
 ERROR_GET_JIRA_ISSUE_WITH_WRONG_TEST_CASE_INDEX=Cannot find TestCase ''{0}'' with index = {1}
+BTN_LINK_JIRA_ISSUE_LABEL=Link JIRA Issue
+BTN_EDIT_JIRA_ISSUE_LINK_LABEL=Edit Issue
+BTN_REMOVE_JIRA_ISSUE_LINK_LABEL=Remove Linked Issue
+TXT_JIRA_ISSUE_KEY_PLACEHOLDER=Enter a Jira issue key
+BTN_OVERRIDE_TEST_CASE_DESCRIPTION_LABEL=Override current test case description
+LBL_LINKING_JIRA_ISSUE_TEXT=Linking issue ...
+LBL_JIRA_ISSUE_NOT_EXISTING_TEXT=Can't find this Jira issue. Try entering another issue key.


### PR DESCRIPTION
### Change summary

- Refactor the `com.katalon.plugin.jira.composer.toolbar.handler.ImportJiraJQLHandler` to reuse logic of linking jira issue for both Import New Test Case and existing test case
- New dialog with `com.katalon.plugin.jira.composer.testcase.JiraIssueLinkDialog` for editing the Jira issue link in a test case
- Change `com.katalon.plugin.jira.composer.testcase.JiraTestCaseIntegrationView` for linking jira issue

