### PR TITLE
[STUDIO-6941] Jira Plugin | test case description in integration tab is not update the full text after link jira test case manually

### DIFF
--- a/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
@@ -169,6 +169,9 @@ public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseInt
         lblDisplaySummary.setText(StringUtils.defaultString(fields.getSummary()));
         lblDisplayStatus.setText(StringUtils.defaultString(fields.getStatus().getName()));
         lblDisplayDiscription.setText(StringUtils.defaultString(fields.getDescription()));
+
+        Composite descriptionParent = lblDisplayDiscription.getParent();
+        descriptionParent.layout();
     }
 
     public boolean hasDocumentation() {


### PR DESCRIPTION
- Fix the UI layout issue for the Jira description field.
- Trigger a layout refresh for the parent container.

<img width="1221" alt="Screenshot 2025-02-06 at 11 04 24" src="https://github.com/user-attachments/assets/caaa5689-113e-4d54-8b79-0be42b29305e" />
