### PR TITLE
[STUDIO-6929] Jira Plugin | When override test case description, Properties tab is not update with override information

### DIFF
--- a/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
@@ -164,16 +164,18 @@ public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseInt
         if (container == null || container.isDisposed()) return;
         ControlUtil.recursiveSetEnabled(container, linkedJiraIssue.isPresent());
 
-        JiraIssue issue = linkedJiraIssue.get();
-        lblDisplayKey.setText("<a>" + issue.getKey() + "</a>");
+        if (linkedJiraIssue.isPresent()) {
+            JiraIssue issue = linkedJiraIssue.get();
+            lblDisplayKey.setText("<a>" + issue.getKey() + "</a>");
 
-        Issue fields = issue.getFields();
-        lblDisplaySummary.setText(StringUtils.defaultString(fields.getSummary()));
-        lblDisplayStatus.setText(StringUtils.defaultString(fields.getStatus().getName()));
-        lblDisplayDiscription.setText(StringUtils.defaultString(fields.getDescription()));
+            Issue fields = issue.getFields();
+            lblDisplaySummary.setText(StringUtils.defaultString(fields.getSummary()));
+            lblDisplayStatus.setText(StringUtils.defaultString(fields.getStatus().getName()));
+            lblDisplayDiscription.setText(StringUtils.defaultString(fields.getDescription()));
 
-        Composite descriptionParent = lblDisplayDiscription.getParent();
-        descriptionParent.layout();
+            Composite descriptionParent = lblDisplayDiscription.getParent();
+            descriptionParent.layout();
+        }
     }
 
     public boolean hasDocumentation() {

--- a/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
@@ -217,7 +217,6 @@ public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseInt
 
     private void redrawJiraIssueKeyColumn() {
         if (lblDisplayKey == null || lblDisplayKey.isDisposed()) return;
-
         Composite parent = lblDisplayKey.getParent();
         if (!linkedJiraIssue.isPresent()) {
             parent = btnLinkJiraIssue.getParent();

--- a/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
+++ b/src/main/java/com/katalon/plugin/jira/composer/testcase/JiraTestCaseIntegrationView.java
@@ -119,6 +119,7 @@ public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseInt
     }
 
     private void setControlVisibility(Control control, boolean visible) {
+        if (control == null || control.isDisposed()) return;
         control.setVisible(visible);
         Object layoutDataRaw = control.getLayoutData();
         if (Objects.nonNull(layoutDataRaw) && layoutDataRaw instanceof GridData) {
@@ -160,6 +161,7 @@ public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseInt
     }
 
     private void populateJiraFieldValues() {
+        if (container == null || container.isDisposed()) return;
         ControlUtil.recursiveSetEnabled(container, linkedJiraIssue.isPresent());
 
         JiraIssue issue = linkedJiraIssue.get();
@@ -214,6 +216,8 @@ public class JiraTestCaseIntegrationView implements JiraUIComponent, TestCaseInt
     }
 
     private void redrawJiraIssueKeyColumn() {
+        if (lblDisplayKey == null || lblDisplayKey.isDisposed()) return;
+
         Composite parent = lblDisplayKey.getParent();
         if (!linkedJiraIssue.isPresent()) {
             parent = btnLinkJiraIssue.getParent();


### PR DESCRIPTION
Resolve issues:
1. org.eclipse.swt.SWTException: Widget is disposed

2. Unable to create integration view for: JIRA
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.get(Optional.java:143)
	at com.katalon.plugin.jira.composer.testcase.JiraTestCaseIntegrationView.populateJiraFieldValues(JiraTestCaseIntegrationView.java:167)